### PR TITLE
Feat: fl add isort

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,3 @@
+[settings]
+skip_glob = */.cache/*.py, 
+            */.cache/*.pyi

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,2 @@
 [settings]
-skip_glob = */.cache/*.py, 
-            */.cache/*.pyi
+skip_glob = */.cache/**/*

--- a/Makefile
+++ b/Makefile
@@ -34,22 +34,27 @@ endif
 
 # CI WORKFLOW
 
-lint: lint-flake lint-black
+lint: lint-flake lint-black lint-isort
 	
 lint-flake:
 	poetry run flake8 .
 
 ifdef INSIDE_CI
-# Inside the CI process, we want to run black 
-# with the --check flag to not change the files
-# but fail if changes should be made
+# Inside the CI process, we want to run black with the --check flag and isort
+# with the --check-only flag to not change the files but fail if changes should be made
 lint-black:
 	poetry run black --check .
 
+lint-isort:
+	poetry run isort -rc . --check-only
+
 else
-# Outside of the CI process, run black normally
+# Outside of the CI process, run black and isort normally
 lint-black:
 	poetry run black .
+
+lint-isort:
+	poetry run isort -rc .
 endif
 
 install-build-system:

--- a/poetry.lock
+++ b/poetry.lock
@@ -576,11 +576,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "4.3.21"
 
-[package.dependencies]
-[package.dependencies.toml]
-optional = true
-version = "*"
-
 [package.extras]
 pipfile = ["pipreqs", "requirementslib"]
 pyproject = ["toml"]
@@ -838,7 +833,7 @@ category = "main"
 description = "YAML parser and emitter for Python"
 name = "pyyaml"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = "*"
 version = "5.3.1"
 
 [[package]]
@@ -1027,7 +1022,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "cd2dc2381a639e9f3c6d872b0c8507f3cc08d64c25d2f45c9fd1a5c0bed31e75"
+content-hash = "587bfc79987e648ae3576835b8b54ba0ad5873865529535fd8c855496dc40c56"
 python-versions = "^3.7"
 
 [metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ coverage = "^5.0.3"
 pytest = "^5.3.5"
 pre-commit = "^2.2.0"
 ipdb = "^0.13.2"
+isort = "^4.3.21"
 
 [tool.black]
 line-length = 130

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "outcome-devkit-py"
-version = "0.2.0"
+version = "0.3.0"
 description = "A package containing common dev dependencies for python projects."
 authors = ["Douglas Willcocks <douglas@outcome.co>"]
 readme = "README.md"


### PR DESCRIPTION
Add isort to the linting steps

- `--check-only` mode for CI process
- ignore `.cache` files